### PR TITLE
Make SurfaceReconstruction an inout param

### DIFF
--- a/splashsurf/src/reconstruction.rs
+++ b/splashsurf/src/reconstruction.rs
@@ -53,7 +53,9 @@ pub(crate) fn entry_point_generic<I: Index, R: Real>(
         splashsurf_lib::reconstruct_surface::<I, R>(particle_positions.as_slice(), &params)?;
 
     let grid = reconstruction.grid();
-    let density_map = reconstruction.density_map();
+    let density_map = reconstruction
+        .density_map()
+        .ok_or_else(|| anyhow::anyhow!("No density map was created during reconstruction"))?;
     let mesh = reconstruction.mesh();
 
     {

--- a/splashsurf_lib/src/mesh.rs
+++ b/splashsurf_lib/src/mesh.rs
@@ -13,8 +13,17 @@ pub struct TriMesh3d<R: Real> {
     pub triangles: Vec<[usize; 3]>,
 }
 
+impl<R: Real> Default for TriMesh3d<R> {
+    fn default() -> Self {
+        Self {
+            vertices: Vec::new(),
+            triangles: Vec::new(),
+        }
+    }
+}
+
 /// A hexahedral (volumetric) mesh in 3D
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct HexMesh3d<R: Real> {
     /// Coordinates of all vertices of the mesh
     pub vertices: Vec<Vector3<R>>,
@@ -23,14 +32,14 @@ pub struct HexMesh3d<R: Real> {
 }
 
 /// A point cloud in 3D
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct PointCloud3d<R: Real> {
     /// Coordinates of all points in the point cloud
     pub points: Vec<Vector3<R>>,
 }
 
 /// A mesh with attached vertex or point data
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MeshWithPointData<MeshT, DataT> {
     /// The mesh geometry itself
     pub mesh: MeshT,

--- a/splashsurf_lib/src/uniform_grid.rs
+++ b/splashsurf_lib/src/uniform_grid.rs
@@ -200,6 +200,16 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
         })
     }
 
+    /// Create a new zeroed grid
+    pub(crate) fn new_zero() -> Self {
+        Self {
+            aabb: AxisAlignedBoundingBox3d::new(Vector3::zeros(), Vector3::zeros()),
+            cell_size: R::zero(),
+            n_points_per_dim: [I::zero(); 3],
+            n_cells_per_dim: [I::zero(); 3],
+        }
+    }
+
     /// Returns the bounding box of the grid
     #[inline(always)]
     pub fn aabb(&self) -> &AxisAlignedBoundingBox3d<R> {


### PR DESCRIPTION
Allows passing own SurfaceReconstruction in new
function that reuses vectors and indices.

The density map is still recalculated for now.