### PR TITLE
Obj format output in reconstruction, and normals outputting for obj format

### DIFF
--- a/splashsurf/src/io.rs
+++ b/splashsurf/src/io.rs
@@ -1,9 +1,12 @@
 use anyhow::{anyhow, Context};
 use log::info;
-use splashsurf_lib::mesh::{Mesh3d, MeshWithData, TriMesh3d};
 use splashsurf_lib::nalgebra::Vector3;
 use splashsurf_lib::profile;
 use splashsurf_lib::Real;
+use splashsurf_lib::{
+    mesh::{Mesh3d, MeshWithData, TriMesh3d},
+    vtkio::model::DataSet,
+};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -166,11 +169,14 @@ pub fn read_surface_mesh<R: Real, P: AsRef<Path>>(
 }
 
 /// Writes a mesh to the given file path, automatically detects the file format
-pub fn write_mesh<R: Real, M: Mesh3d<R>, P: AsRef<Path>>(
-    mesh: &MeshWithData<R, M>,
+pub fn write_mesh<'a, R: Real, MeshT: Mesh3d<R>, P: AsRef<Path>>(
+    mesh: &'a MeshWithData<R, MeshT>,
     output_file: P,
     _format_params: &OutputFormatParameters,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), anyhow::Error>
+where
+    &'a MeshWithData<R, MeshT>: Into<DataSet>,
+{
     let output_file = output_file.as_ref();
     info!(
         "Writing mesh with {} vertices and {} cells to \"{}\"...",
@@ -187,11 +193,27 @@ pub fn write_mesh<R: Real, M: Mesh3d<R>, P: AsRef<Path>>(
             .ok_or(anyhow!("Invalid extension of output file"))?;
 
         match extension.to_lowercase().as_str() {
-            "obj" => obj_format::mesh_to_obj(mesh, &output_file)?,
+            "vtk" => {
+                vtk_format::write_vtk(mesh, &output_file, "mesh").with_context(|| {
+                    format!(
+                        "Failed to write reconstructed surface to output file '{}'",
+                        output_file.to_string_lossy()
+                    )
+                })?;
+            }
+            "obj" => {
+                obj_format::mesh_to_obj(mesh, &output_file).with_context(|| {
+                    format!(
+                        "Failed to write reconstructed surface to output file '{}'",
+                        output_file.to_string_lossy()
+                    )
+                })?;
+            }
             _ => {
                 return Err(anyhow!(
-                    "Unsupported file format extension \"{}\" for writing meshes",
-                    extension
+                    "Unsupported file format extension \"{}\" for writing mesh to output file '{}'",
+                    extension,
+                    output_file.to_string_lossy(),
                 ));
             }
         }

--- a/splashsurf/src/io/obj_format.rs
+++ b/splashsurf/src/io/obj_format.rs
@@ -43,7 +43,11 @@ pub fn mesh_to_obj<R: Real, M: Mesh3d<R>, P: AsRef<Path>>(
 
     for f in mesh_vertices.cells() {
         write!(writer, "f")?;
-        f.try_for_each_vertex(|v| write!(writer, " {}", v + 1))?;
+        if let Some(_) = normals {
+            f.try_for_each_vertex(|v| write!(writer, " {}//{}", v + 1, v + 1))?;
+        } else {
+            f.try_for_each_vertex(|v| write!(writer, " {}", v + 1))?;
+        }
         write!(writer, "\n")?;
     }
 

--- a/splashsurf/src/io/obj_format.rs
+++ b/splashsurf/src/io/obj_format.rs
@@ -19,12 +19,29 @@ pub fn mesh_to_obj<R: Real, M: Mesh3d<R>, P: AsRef<Path>>(
         .context("Failed to open file handle for writing OBJ file")?;
     let mut writer = BufWriter::with_capacity(100000, file);
 
-    let mesh = &mesh.mesh;
-    for v in mesh.vertices() {
+    let mesh_vertices = &mesh.mesh;
+
+    for v in mesh_vertices.vertices() {
         write!(&mut writer, "v {} {} {}\n", v.x, v.y, v.z)?;
     }
 
-    for f in mesh.cells() {
+    let normals = mesh
+        .point_attributes
+        .iter()
+        .find(|attrib| attrib.name == "normals");
+
+    if let Some(normals) = normals {
+        match &normals.data {
+            splashsurf_lib::mesh::AttributeData::Vector3Real(normals) => {
+                for n in normals {
+                    write!(&mut writer, "vn {} {} {}\n", n.x, n.y, n.z)?;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    for f in mesh_vertices.cells() {
         write!(writer, "f")?;
         f.try_for_each_vertex(|v| write!(writer, " {}", v + 1))?;
         write!(writer, "\n")?;

--- a/splashsurf/src/reconstruction.rs
+++ b/splashsurf/src/reconstruction.rs
@@ -605,12 +605,41 @@ pub(crate) fn reconstruction_pipeline_generic<I: Index, R: Real>(
             "Writing surface mesh to \"{}\"...",
             paths.output_file.to_string_lossy()
         );
-        io::vtk_format::write_vtk(&mesh, &paths.output_file, "mesh").with_context(|| {
-            format!(
-                "Failed to write reconstructed surface to output file '{}'",
-                paths.output_file.to_string_lossy()
-            )
-        })?;
+
+        let extension = paths
+            .output_file
+            .extension()
+            .map(|s| s.to_str().unwrap_or("vtk"))
+            .unwrap_or("vtk");
+
+        match extension.to_lowercase().as_str() {
+            "vtk" => {
+                io::vtk_format::write_vtk(&mesh, &paths.output_file, "mesh").with_context(
+                    || {
+                        format!(
+                            "Failed to write reconstructed surface to output file '{}'",
+                            paths.output_file.to_string_lossy()
+                        )
+                    },
+                )?;
+            }
+            "obj" => {
+                io::obj_format::mesh_to_obj(&mesh, &paths.output_file).with_context(|| {
+                    format!(
+                        "Failed to write reconstructed surface to output file '{}'",
+                        paths.output_file.to_string_lossy()
+                    )
+                })?;
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Unsupported file format extension \"{}\" for writing reconstructed surface to output file '{}'",
+                    extension,
+                    paths.output_file.to_string_lossy(),
+                ));
+            }
+        }
+
         info!("Done.");
     }
 

--- a/splashsurf/src/reconstruction.rs
+++ b/splashsurf/src/reconstruction.rs
@@ -606,39 +606,9 @@ pub(crate) fn reconstruction_pipeline_generic<I: Index, R: Real>(
             paths.output_file.to_string_lossy()
         );
 
-        let extension = paths
-            .output_file
-            .extension()
-            .map(|s| s.to_str().unwrap_or("vtk"))
-            .unwrap_or("vtk");
+        let io_params = io::FormatParameters::default();
 
-        match extension.to_lowercase().as_str() {
-            "vtk" => {
-                io::vtk_format::write_vtk(&mesh, &paths.output_file, "mesh").with_context(
-                    || {
-                        format!(
-                            "Failed to write reconstructed surface to output file '{}'",
-                            paths.output_file.to_string_lossy()
-                        )
-                    },
-                )?;
-            }
-            "obj" => {
-                io::obj_format::mesh_to_obj(&mesh, &paths.output_file).with_context(|| {
-                    format!(
-                        "Failed to write reconstructed surface to output file '{}'",
-                        paths.output_file.to_string_lossy()
-                    )
-                })?;
-            }
-            _ => {
-                return Err(anyhow!(
-                    "Unsupported file format extension \"{}\" for writing reconstructed surface to output file '{}'",
-                    extension,
-                    paths.output_file.to_string_lossy(),
-                ));
-            }
-        }
+        io::write_mesh(&mesh, paths.output_file.clone(), &io_params.output)?;
 
         info!("Done.");
     }


### PR DESCRIPTION
This adds obj files as a supported format from reconstruction, and enables normals output if requested.

Still need to add docs updates, and I have not tested this thoroughly, so apologies if there are mistakes.

Thanks